### PR TITLE
Add support of Intel IACA for data-dependency analyzing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ matmul2d_jk_vec_k_gather.o matmul2d_jk_vec_k_no_gather.o matmul2d_jk_vec_j.o \
 matmul2d_jk_vec_jk_bcast.o
 
 CFLAGS = -Wall -g -O2 -fopenmp -D N=2048 -D EPS=10E-15
-ASFLAGS = -m64 -D N=2048 -D HW_CACHELINE_SIZE=64
+#ASFLAGS = -m64 -D N=2048 -D HW_CACHELINE_SIZE=64
+ASFLAGS = -m64 -D N=2048 -D HW_CACHELINE_SIZE=64 -D USE_IACA
 LDFLAGS = -lnuma
 
 all: $(OBJS_matmul)

--- a/matmul.h
+++ b/matmul.h
@@ -30,8 +30,27 @@ int check_results(int);
 .global tsc_tmp
 
 .macro get_tsc var
+    xorl %eax, %eax
+    cpuid
     rdtsc
     mov %eax, \var
     mov %edx, \var+0x4
 .endm
+
+#ifdef USE_IACA
+.macro IACA_START_MARKER
+    movl $111, %ebx
+    .byte 0x64, 0x67, 0x90
+.endm
+.macro IACA_END_MARKER
+    movl $222, %ebx
+    .byte 0x64, 0x67, 0x90
+.endm
+#else
+.macro IACA_START_MARKER
+.endm
+.macro IACA_END_MARKER
+.endm
+#endif
+
 #endif /* __ASSEMBLER__ */

--- a/matmul2d_kj_vec_j.S
+++ b/matmul2d_kj_vec_j.S
@@ -31,6 +31,7 @@ matmul2d_kj_vec_j:
 	.p2align 4,,10
 	.p2align 3
 .L5: /* j loop */
+	IACA_START_MARKER
 	vmovupd	(%rsi,%rax), %ymm0 					  /* C[k][j + 0:3] */
 	vmovupd	(%rcx,%rax), %ymm1					  /* A[i][j + 0:3] */
 
@@ -42,6 +43,7 @@ matmul2d_kj_vec_j:
 	addq	$32, %rax                             /* j = j + 4 */
 	cmpq	$STR_SIZE, %rax                       /* j == STR_SIZE ? j loop is over */
 	jne	.L5
+	IACA_END_MARKER
 	addq	$STR_SIZE, %rsi                       /* C[k + 1][j] */  
 	addq	$8, %rdi                              /* B[i][k + 1] */
 	cmpq	%rdx, %rsi                            /* C[k + 1][j] == C[N - 1][j] ? k loop is over */

--- a/run-iaca.sh
+++ b/run-iaca.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Intel Sandy Bridge
+iaca -arch SNB -o iaca-out.out -graph iaca-out  ./matmul
+dot -Tps ./iaca-out1.dot > iaca-out.ps
+


### PR DESCRIPTION
Add support of Intel IACA for data-dependency analyzing

https://software.intel.com/en-us/articles/intel-architecture-code-analyzer

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>